### PR TITLE
Fix for 25 batch email regex

### DIFF
--- a/src/routes/NameRouter.ts
+++ b/src/routes/NameRouter.ts
@@ -76,7 +76,7 @@ router.delete("/:name/:password", async (req, res) => {
 
 router.get("/:email", async(req, res) => {
     const email : string = req.params.email.toLowerCase().trim() || ""
-    const regex = /^[a-z]+\.(23|24)bcs[1-9][0-9]{4}@sst\.scaler\.com$/;
+    const regex = /^[a-z]+\.(23|24|25)bcs[1-9][0-9]{4}@sst\.scaler\.com$/;
 
     interface ReturnObjInterface {
         start_time: string;


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Allow batch 25 in the BCS email regex pattern